### PR TITLE
Fix Firebase static hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Firebase Hosting
+
+This project is configured for static export. Run `npm run build` to generate the
+`out` directory, then deploy it to Firebase Hosting with `firebase deploy`.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "export",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- enable static export in `next.config.ts`
- document how to deploy to Firebase Hosting

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68451b9e71708329815def8a0a11ec3c