### PR TITLE
Fix auth page build failure

### DIFF
--- a/src/app/(GroupA)/auth/page.tsx
+++ b/src/app/(GroupA)/auth/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Suspense } from 'react';
+
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
@@ -15,6 +17,14 @@ import { Button, TextInput, Alert, Spinner } from 'flowbite-react';
 import useUserRoles from '@/hooks/useUserRoles';
 
 export default function AuthPage() {
+  return (
+    <Suspense>
+      <AuthForm />
+    </Suspense>
+  );
+}
+
+function AuthForm() {
   const router          = useRouter();
   const params          = useSearchParams();
   const inviteToken     = params.get('token');               // ?token=abc


### PR DESCRIPTION
## Summary
- wrap auth page in Suspense to satisfy useSearchParams requirement

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68458be3858083298fa27ed7299e74b9